### PR TITLE
Resubscribe to existing subscriptions upon reconnect

### DIFF
--- a/src/BaseBlockbook.ts
+++ b/src/BaseBlockbook.ts
@@ -1,6 +1,6 @@
 import { BlockHashResponseWs, GetBlockOptions, SubscribeAddressesEvent, SubscribeNewBlockEvent } from './types/common';
 import request from 'request-promise-native'
-import { assertType, DelegateLogger, isMatchingError, isString, Logger } from '@faast/ts-common'
+import { assertType, DelegateLogger, isMatchingError, isString, isUndefined, Logger } from '@faast/ts-common'
 import * as t from 'io-ts'
 import WebSocket from 'ws'
 
@@ -20,6 +20,10 @@ const xpubDetailsCodecs = {
   txids: XpubDetailsTxids,
   txs: XpubDetailsTxs,
 }
+
+type PendingWsRequests = { [id: string]: { resolve: Resolve, reject: Reject } }
+type SubscriptionData = { callback: Resolve, method: string, params: object }
+type SubscriptionIdToData = { [id: string]: SubscriptionData }
 
 /**
  * Blockbook client with support for both http and ws with multi-node and type validation support.
@@ -49,10 +53,9 @@ export abstract class BaseBlockbook<
 
   private requestCounter = 0
   private pingIntervalId: NodeJS.Timeout
-  private pendingWsRequests: { [id: string]: { resolve: Resolve, reject: Reject } } = {}
-  private subscriptions: { [id: string]: { callback: Resolve, method: string } } = {}
-  private subscribeNewBlockId = ''
-  private subscribeAddressesId = ''
+  private pendingWsRequests: PendingWsRequests = {}
+  private subscriptionIdToData: SubscriptionIdToData = {}
+  private subscribtionMethodToId: Record<string, string> = {}
 
   static WS_NORMAL_CLOSURE_CODES = [1000, 1005]
 
@@ -101,14 +104,14 @@ export abstract class BaseBlockbook<
 
 
   /** Load balance using round robin. Helps any retry logic fallback to different nodes */
-  private getNode() {
+  private pickNode() {
     return this.nodes[this.requestCounter++ % this.nodes.length]
   }
 
   async httpRequest(
     method: 'GET' | 'POST', path: string, params?: object, body?: object, options?: Partial<request.Options>,
   ) {
-    const response = jsonRequest(this.getNode(), method, path, params, body, {
+    const response = jsonRequest(this.pickNode(), method, path, params, body, {
       timeout: this.requestTimeoutMs,
       ...options,
     })
@@ -137,25 +140,43 @@ export abstract class BaseBlockbook<
 
   async subscribe(method: string, params: object, callback: (result: any) => void) {
     const id = (this.requestCounter++).toString()
-    this.subscriptions[id] = { callback, method }
+    this.subscriptionIdToData[id] = { callback, method, params }
     const result = await this.wsRequest(method, params, id)
-    return [id, result]
-  }
-
-  unsubscribe(method: string, params: object, id: string) {
-    const result = this.wsRequest(method, params, id)
-    delete this.subscriptions[id]
+    // Only one of each subscription can exist at once so delete the old one if it exists
+    const oldSubscriptionId = this.subscribtionMethodToId[method]
+    if (oldSubscriptionId) {
+      delete this.subscriptionIdToData[oldSubscriptionId]
+    }
+    this.subscribtionMethodToId[method] = id
     return result
   }
 
-  private reconnect(baseDelay: number) {
+  async unsubscribe(method: string, params: object, subscribedMethod: string) {
+    const subscriptionId = this.subscribtionMethodToId[subscribedMethod]
+    if (isUndefined(subscriptionId)) {
+      return { subscribed: false }
+    }
+    delete this.subscribtionMethodToId[subscribedMethod]
+    delete this.subscriptionIdToData[subscriptionId]
+    return this.wsRequest(method, params, subscriptionId)
+  }
+
+  /**
+   * Recursively reconnect to websocket with exponential backoff delay.
+   * Resubscribe existingSubscriptions upon reconnecting.
+   */
+  private reconnect(baseDelay: number, existingSubscriptions: SubscriptionData[]) {
     const reconnectMs = Math.round(baseDelay * (1 + Math.random()))
     this.logger.log(`socket reconnecting in ${reconnectMs/1000}s to one of`, this.nodes)
     setTimeout(async () => {
       try {
         await this.connect()
+        // Resubscribe to subscriptions that existed before disconnection
+        for (let subscription of existingSubscriptions) {
+          await this.subscribe(subscription.method, subscription.params, subscription.callback)
+        }
       } catch (e) {
-        this.reconnect(Math.max(60 * 1000, baseDelay * 2))
+        this.reconnect(Math.max(60 * 1000, baseDelay * 2), existingSubscriptions)
       }
     }, reconnectMs)
   }
@@ -166,10 +187,9 @@ export abstract class BaseBlockbook<
       return this.wsConnectedNode
     }
     this.pendingWsRequests = {}
-    this.subscriptions = {}
-    this.subscribeNewBlockId = ''
-    this.subscribeAddressesId = ''
-    let node = this.getNode()
+    this.subscriptionIdToData = {}
+    this.subscribtionMethodToId = {}
+    let node = this.pickNode()
     if (node.startsWith('http')) {
       node = node.replace('http', 'ws')
     }
@@ -202,7 +222,7 @@ export abstract class BaseBlockbook<
       this.wsConnectedNode = undefined
       clearInterval(this.pingIntervalId)
       if (!BaseBlockbook.WS_NORMAL_CLOSURE_CODES.includes(code) && this.reconnectDelayMs > 0) {
-        this.reconnect(this.reconnectDelayMs)
+        this.reconnect(this.reconnectDelayMs, Object.values(this.subscriptionIdToData))
       }
     })
     this.ws.on('error', (e) => {
@@ -242,7 +262,7 @@ export abstract class BaseBlockbook<
           }
           return pendingRequest.resolve(result)
       }
-      const activeSubscription = this.subscriptions[id]
+      const activeSubscription = this.subscriptionIdToData[id]
       if (activeSubscription) {
         if (errorMessage) {
           this.logger.error(
@@ -422,9 +442,7 @@ export abstract class BaseBlockbook<
     cb: (e: SubscribeAddressesEvent) => void,
   ): Promise<{ subscribed: true }> {
     this.assertWsConnected('call subscribeAddresses')
-    const [subscriptionId, result] = await this.subscribe('subscribeAddresses', { addresses }, cb)
-    this.subscribeAddressesId = subscriptionId
-    return result
+    return this.subscribe('subscribeAddresses', { addresses }, cb)
   }
 
   /**
@@ -432,7 +450,7 @@ export abstract class BaseBlockbook<
    */
   async unsubscribeAddresses(): Promise<{ subscribed: false }> {
     this.assertWsConnected('call unsubscribeAddresses')
-    return this.unsubscribe('unsubscribeAddresses', {}, this.subscribeAddressesId)
+    return this.unsubscribe('unsubscribeAddresses', {}, 'subscribeAddresses')
   }
 
   /**
@@ -440,9 +458,7 @@ export abstract class BaseBlockbook<
    */
   async subscribeNewBlock(cb: (e: SubscribeNewBlockEvent) => void): Promise<{ subscribed: true }> {
     this.assertWsConnected('call subscribeNewBlock')
-    const [subscriptionId, result] = await this.subscribe('subscribeNewBlock', {}, cb)
-    this.subscribeNewBlockId = subscriptionId
-    return result
+    return this.subscribe('subscribeNewBlock', {}, cb)
   }
 
   /**
@@ -450,6 +466,6 @@ export abstract class BaseBlockbook<
    */
   async unsubscribeNewBlock(): Promise<{ subscribed: false }> {
     this.assertWsConnected('call unsubscribeNewBlock')
-    return this.unsubscribe('unsubscribeNewBlock', {}, this.subscribeNewBlockId)
+    return this.unsubscribe('unsubscribeNewBlock', {}, 'subscribeNewBlock')
   }
 }


### PR DESCRIPTION
Upon encountering an unexpected websocket closure the reconnect logic will attempt to reconnect forever using an exponential backoff delay. However, upon reconnecting a new websocket is established so all previous subscriptions will be reset.

- Call subscribe for all previous subscriptions upon successfully reconnecting using the original params and callback
- Multiple calls to the same subscribe methods will now correctly overwrite the previous subscription and avoid a memory leak (albeit a small one).
- Upon websocket closure all pending requests will be rejected with an appropriate error