### PR TITLE
test with another  address

### DIFF
--- a/src/types/ethereum.ts
+++ b/src/types/ethereum.ts
@@ -1,5 +1,5 @@
 import * as t from 'io-ts'
-import { extendCodec } from '@faast/ts-common'
+import { extendCodec, optional } from '@faast/ts-common'
 import {
   NormalizedTxCommonVin, NormalizedTxCommonVout, NormalizedTxCommon, paginated,
   EthereumSpecific, TokenDetailsTypeERC20, AddressDetailsCommonBasic, BlockInfoCommon,
@@ -80,14 +80,14 @@ export const TokenDetailsERC20 = t.type({
   name: t.string, // 'Carrots',
   contract: t.string, // '0x6e0646b014d99d79f4e875b6723fa8e46becbd15',
   transfers: t.number, // 1,
-  symbol: t.string, // 'CEN',
+  symbol: optional(t.string), // 'CEN',
 }, 'TokenDetailsERC20')
 export type TokenDetailsERC20 = t.TypeOf<typeof TokenDetailsERC20>
 
 export const TokenDetailsERC20Balance = extendCodec(
   TokenDetailsERC20,
   {
-    balance: t.string, // '8503600000000000000'
+    balance: optional(t.string), // '8503600000000000000'
   },
   'TokenDetailsERC20Balance',
 )
@@ -96,7 +96,7 @@ export type TokenDetailsERC20Balance = t.TypeOf<typeof TokenDetailsERC20Balance>
 export const AddressDetailsEthereumBasic = extendCodec(
   AddressDetailsCommonBasic,
   {
-    nonTokenTxs: t.number, // 29483,
+    nonTokenTxs: optional(t.number), // 29483,
     nonce: t.string, // '1',
   },
   'AddressDetailsEthereumBasic'
@@ -107,7 +107,7 @@ export const AddressDetailsEthereumTokens = extendCodec(
   AddressDetailsEthereumBasic,
   {},
   {
-    tokens: TokenDetailsERC20,
+    tokens: t.array(TokenDetailsERC20),
   },
   'AddressDetailsEthereumTokens'
 )
@@ -117,7 +117,7 @@ export const AddressDetailsEthereumTokenBalances = extendCodec(
   AddressDetailsEthereumBasic,
   {},
   {
-    tokens: TokenDetailsERC20Balance,
+    tokens: t.array(TokenDetailsERC20Balance),
   },
   'AddressDetailsEthereumTokenBalances'
 )

--- a/test/BlockbookEthereum.test.ts
+++ b/test/BlockbookEthereum.test.ts
@@ -33,7 +33,7 @@ describe('BlockbookEthereum', () => {
   })
   describe('getAddressDetails', () => {
     it('succeeds', async () => {
-      expect(await bb.getAddressDetails(ADDRESS)).toBeDefined()
+      expect(await bb.getAddressDetails('0x176366cFD97885245fAEA72f8cB6951e52655Adf')).toBeDefined()
     })
   })
   describe('getXpubDetails', () => {

--- a/test/BlockbookEthereum.test.ts
+++ b/test/BlockbookEthereum.test.ts
@@ -5,7 +5,8 @@ const BLOCK_NUMBER = 1000000
 const BLOCK_HASH = '0x8e38b4dbf6b11fcc3b9dee84fb7986e29ca0a02cecd8977c161ff7333329681e'
 const ADDRESS = '0xFc32E838dD435c1904C3AAD640Dc7B419e9c891d'
 const TXID = '0xf09499a7e72ccf66a0cac01eeb5f5616f275dd4f103e3c0415fbb6e1997ed373'
-const RAW_TX = '0xf870830162988502540be40083186a0094fc32e838dd435c1904c3aad640dc7b419e9c891d8801e062bbbd1d11008026a01f4ba49998c3f4f34ffea6e05eb94bca642e532f776f28fa10c32e1081d42673a01016ad652bb3b4a3b9b68bd81fe48a15b3f1b53385434e395d3990a396652238'
+const RAW_TX =
+  '0xf870830162988502540be40083186a0094fc32e838dd435c1904c3aad640dc7b419e9c891d8801e062bbbd1d11008026a01f4ba49998c3f4f34ffea6e05eb94bca642e532f776f28fa10c32e1081d42673a01016ad652bb3b4a3b9b68bd81fe48a15b3f1b53385434e395d3990a396652238'
 
 describe('BlockbookEthereum', () => {
   const bb = new BlockbookEthereum({
@@ -31,9 +32,22 @@ describe('BlockbookEthereum', () => {
       expect(await bb.getTxSpecific(TXID)).toBeDefined()
     })
   })
+
   describe('getAddressDetails', () => {
     it('succeeds', async () => {
+      expect(await bb.getAddressDetails(ADDRESS)).toBeDefined()
+    })
+  })
+
+  describe('getAddressDetails2', () => {
+    it('succeeds', async () => {
       expect(await bb.getAddressDetails('0x176366cFD97885245fAEA72f8cB6951e52655Adf')).toBeDefined()
+    })
+  })
+
+  describe('getAddressDetails - faa.st wallet', () => {
+    it('succeeds', async () => {
+      expect(await bb.getAddressDetails('0x94fe3ad91dacba8ec4b82f56ff7c122181f1535d')).toBeDefined()
     })
   })
   describe('getXpubDetails', () => {


### PR DESCRIPTION
# Description of the change

The getAddress details test fails when it's tested with this address `0x176366cFD97885245fAEA72f8cB6951e52655Adf`. The types break with the error below. I believe this  is due to the fact that some expected fields are undefined. 

```sh
  ● BlockbookEthereum › getAddressDetails › succeeds

    TypeError: Invalid type - Expected type number for (Paginated & AddressDetailsEthereumTxids).nonTokenTxs, but got: undefined

      127 |       return value as T
      128 |     }
    > 129 |     return assertType(codec, value, ...rest)
          |            ^
      130 |   }
```

The address details looks like this via blockbook api https://eth1.trezor.io/api/address/0x176366cFD97885245fAEA72f8cB6951e52655Adf

```ts
{
page: 1,
totalPages: 1,
itemsOnPage: 1000,
address: "0x176366cFD97885245fAEA72f8cB6951e52655Adf",
balance: "0",
unconfirmedBalance: "0",
unconfirmedTxs: 0,
txs: 0,
nonce: "0"
}
```