### PR TITLE
Clean up subscribe handler on failed request

### DIFF
--- a/src/BaseBlockbook.ts
+++ b/src/BaseBlockbook.ts
@@ -192,7 +192,14 @@ export abstract class BaseBlockbook<
   async subscribe(method: string, params: object, callback: (result: any) => void | Promise<void>) {
     const id = (this.requestCounter++).toString()
     this.subscriptionIdToData[id] = { callback, method, params }
-    const result = await this.wsRequest(method, params, id)
+    let result
+    try {
+      result = await this.wsRequest(method, params, id)
+    } catch (e) {
+      // If request fails, delete our handler
+      delete this.subscriptionIdToData[id]
+      throw e
+    }
     // Only one of each subscription can exist at once so delete the old one if it exists
     const oldSubscriptionId = this.subscribtionMethodToId[method]
     if (oldSubscriptionId) {


### PR DESCRIPTION
If subscribe fails, such as due to a timeout, the event handler is still stored in memory. We need to clean this up to avoid a small memory leak and prevent the actual event handler callback from throwing an error when if it eventually sees a `{ subscribe: true }` response.